### PR TITLE
Updated the AwsSddcConfig call to handle vpc_name deprecation and sin…

### DIFF
--- a/docker/container_volume/awsvmc.py
+++ b/docker/container_volume/awsvmc.py
@@ -280,12 +280,24 @@ class ORG(object):
                 name=sddcName,
                 vxlan_subnet=podConfig.VxlanSubnet,
                 vpc_cidr=podConfig.ManagementCidr,
-                vpc_name=None,
                 provider=self.config.WorkshopConfig.Provider,
                 sso_domain=self.config.WorkshopConfig.SsoDomain,
                 num_hosts=self.config.WorkshopConfig.NumHosts,
                 deployment_type=self.config.WorkshopConfig.DeploymentType,
                 region=self.config.WorkshopConfig.Region)
+
+        # For single node cluster, an extra flag must be set
+        if sddcConfig.num_hosts == 1:
+            sddcConfig.sddc_type = "1NODE"
+
+        # For legacy API/SDK combinations, there was a setting for vpc_name
+        # that was later removed from the prototype.  The following check
+        # ensures backwards compatability
+        try:
+            getattr(sddcConfig, 'vpc_name')
+            sddcConfig.vpc_name = None
+        except AttributeError:
+            pass
 
         if verbose:
             print(sddcConfig)


### PR DESCRIPTION
…gle node

The function prototype changed and so this commit handles both
the new and the old prototype.  This will also deploy single node
clusters.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
